### PR TITLE
Fixing a bug in sitemap url generation

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,10 +53,8 @@ module.exports = (options, ctx) => {
                     }
                 }
 
-                const sitemapUrl = host + sitemap;
-
                 robotstxt({
-                    policy: policyArray, sitemap: sitemapUrl.replace(/\/\//g,"/"), host: host
+                    policy: policyArray, sitemap: host + sitemap.replace(/\/\//g,"/"), host: host
                 }).then(content => {
                     // All good, save the file
                     fs.writeFileSync(robotsTxt, content)


### PR DESCRIPTION
Fix a bug where "https://domain/sitemap.xml" gets generated as "https:/domain/sitemap.xml" (notice the single forward slash for host).
The regex should only apply to the path of the url not to the host+protocol.